### PR TITLE
Remove `n.samples` argument to `HUMPBACK.SIR`

### DIFF
--- a/R/Humpback_SIR_20171206.R
+++ b/R/Humpback_SIR_20171206.R
@@ -7,7 +7,6 @@
 #'
 #' @param file.name name of a file to identified the files exported by the
 #'   function
-#' @param n.samples number of samples for the Rubin SIR: NOT USED
 #' @param n.resamples number of resamples to compute the marginal posterior
 #'   distributions
 #' @param prior.K prior for K for future use with the forward method: NOT USED
@@ -76,7 +75,6 @@
 #'
 #' \dontrun{
 #' HUMPBACK.SIR(file.name = "test.N2005",
-#'              n.samples = NULL,
 #'              n.resamples = 1000,
 #'              prior.K = c(NA, NA, NA),
 #'              prior.r_max = c("uniform", 0, 0.106),
@@ -103,7 +101,6 @@
 #'              Print = 0)
 #' }
 HUMPBACK.SIR <- function(file.name = "NULL",
-                         n.samples = 1000,
                          n.resamples = 1000,
                          prior.K = c(NA, NA, NA),
                          prior.r_max = c("uniform", 0, 0.12),
@@ -134,8 +131,6 @@ HUMPBACK.SIR <- function(file.name = "NULL",
   ################################
   # Assigning variables
   ################################
-  ## Not used as I am not doing the Rubin (1988) SIR anymore.
-  n.samples <- n.samples
   target.Yr <- target.Yr
   ## Use the first year of the projection is set as the first year in the
   ## catch series

--- a/tests/testthat/test_sir.R
+++ b/tests/testthat/test_sir.R
@@ -3,7 +3,6 @@ context("SIR")
 test_that("Example runs", {
   set.seed(48448)
   sir <- HUMPBACK.SIR(file.name = "test.N2005",
-                      n.samples = NULL,
                       n.resamples = 100,
                       prior.K = c(NA, NA, NA),
                       prior.r_max = c("uniform", 0, 0.106),


### PR DESCRIPTION
Not used anywhere. There are other arguments that could also be removed, but I need to dive into them a bit more.

NOTE: This will be easier to merge after #21.